### PR TITLE
Upgrading script to support fetching of higher resolution photo

### DIFF
--- a/download_parentzone_photos.py
+++ b/download_parentzone_photos.py
@@ -67,12 +67,12 @@ def get_parentzone_photos(email, password, output_folder):
 
         # For each image that we've found
         for element in media_elements:
-            image_url = element.get_attribute('src').replace("/thumbnail", "")
+            image_url = element.get_attribute('src').replace("/thumbnail", "/full")
             print(image_url)
-            image_id = image_url[image_url.rfind("/") + 1:image_url.find("?")]
-            
+                        
             # Skip images not from gallery
             if (image_url.__contains__("api.parentzone.me/v1/media")):
+                image_id = image_url[image_url.rfind("media/") + 6:image_url.find("/full")]
 
                 if int(image_id) < lowest_image_id:
                     lowest_image_id = int(image_id)


### PR DESCRIPTION
By default, the script will only download a marginally higher quality image than the thumbnail. By changing the URL, it's possible to download the full resolution photo.